### PR TITLE
fix:- double entry in browser history when loading data listing page

### DIFF
--- a/pages/[datasets]/index.tsx
+++ b/pages/[datasets]/index.tsx
@@ -44,7 +44,7 @@ const Datasets: React.FC<Props> = ({ data, facets }) => {
       ? datasets.toString().toLowerCase()
       : pageTitle[0];
 
-    router.push({
+    router.replace({
       pathname: '/[datasets]',
       query: {
         fq: datsetsFilters,
@@ -59,8 +59,7 @@ const Datasets: React.FC<Props> = ({ data, facets }) => {
 
 
   function handleDatasetsChange(val: any) {
-    
-    
+  
     switch (val.query) {
       case 'q':
         setSearch(val.value);

--- a/pages/[datasets]/index.tsx
+++ b/pages/[datasets]/index.tsx
@@ -59,7 +59,6 @@ const Datasets: React.FC<Props> = ({ data, facets }) => {
 
 
   function handleDatasetsChange(val: any) {
-  
     switch (val.query) {
       case 'q':
         setSearch(val.value);


### PR DESCRIPTION
we were using router.push for going to the /datasets page and for adding the filters again we were again using router.push .(router.push add a new URL entry to the browser history while router.replace will prevent adding a new URL entry into the history stack.)  Fixes the issue #53 